### PR TITLE
Changed '[' usage to shell if statement for docker move.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,9 @@ pi-minimal.img: build/binary.img
 		destfile="pi-minimal-$$(basename "$$file")" ; \
 		cp "$$file" "$$destfile" ; \
 	done
-	[ -f /.dockerinit ] && [ -f pi-minimal.img ] && mv pi-minimal.img /raspbian-live-build/
+	if [ -f /.dockerinit -a -f pi-minimal.img ]; then \
+		mv pi-minimal.img /raspbian-live-build/; \
+	fi
 
 dist-clean:
 	-sudo rm -rf build


### PR DESCRIPTION
Using `[ -f ... ] && [ -f ...] && command` means that `make` will always encounter an error if you're not building a docker image (because the whole expression is false). A shell `if` statement seems to be the sensible thing to do here (you'll still get the error unlike `A && B || C` or similar construct).
